### PR TITLE
Fix/resource route missing impl

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -26,7 +26,7 @@ return array(
 	'label' => 'Model Browser',
 	'description' => 'Developement tool to browse the generis ontology',
     'license' => 'GPL-2.0',
-    'version' => '5.0.0',
+    'version' => '5.0.1',
 	'author' => 'Open Assessment Technologies',
     'requires' => array(
         'tao'           => '>=21.0.0',

--- a/model/Updater.php
+++ b/model/Updater.php
@@ -27,6 +27,6 @@ class Updater extends \common_ext_ExtensionUpdater {
      * @see \common_ext_ExtensionUpdater::update()
      */
     public function update($initialVersion) {
-        $this->skip('2.6', '5.0.0');
+        $this->skip('2.6', '5.0.1');
     }
 }

--- a/model/route/ResourceRoute.php
+++ b/model/route/ResourceRoute.php
@@ -41,7 +41,7 @@ class ResourceRoute implements Route
 
     public static function getControllerPrefix()
     {
-        return '';
+        return 'oat\\ontoBrowser\\actions\\Browse';
     }
 
 }

--- a/model/route/ResourceRoute.php
+++ b/model/route/ResourceRoute.php
@@ -22,7 +22,7 @@ namespace oat\ontoBrowser\model\route;
 use oat\tao\model\routing\Route;
 use Psr\Http\Message\ServerRequestInterface;
 
-class ResourceRoute extends Route
+class ResourceRoute implements Route
 {
     public function resolve(ServerRequestInterface $request)
     {
@@ -37,6 +37,11 @@ class ResourceRoute extends Route
             // namespace does not match URL, aborting
         }
         return null;
+    }
+
+    public static function getControllerPrefix()
+    {
+        return '';
     }
 
 }

--- a/model/route/ResourceRoute.php
+++ b/model/route/ResourceRoute.php
@@ -19,10 +19,10 @@
  */
 namespace oat\ontoBrowser\model\route;
 
-use oat\tao\model\routing\Route;
 use Psr\Http\Message\ServerRequestInterface;
+use oat\tao\model\routing\AbstractRoute;
 
-class ResourceRoute implements Route
+class ResourceRoute extends AbstractRoute
 {
     public function resolve(ServerRequestInterface $request)
     {
@@ -30,7 +30,7 @@ class ResourceRoute implements Route
         $config = $this->getConfig();
         try {
             $relNs = \tao_helpers_Request::getRelativeUrl($config['namespace']);
-            if (substr($relativeUrl, 0, strlen($relNs)) == $relNs) {
+            if (strlen($relNs) != '' && substr($relativeUrl, 0, strlen($relNs)) == $relNs) {
                 return 'oat\\ontoBrowser\\actions\\Browse@standAlone';
             }
         } catch (\ResolverException $r) {


### PR DESCRIPTION
This PR fixes a platform crash while ontoBrowser extension is installed. A missing method implement of the `Route` interface was missing.